### PR TITLE
Update dev-requirements.in with fonttools

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -5,3 +5,4 @@
 # https://github.com/jazzband/pip-tools
 
 black
+fonttools


### PR DESCRIPTION
Other imports look like they are part of the python standard distribution, and while practically we could assume any user of this has fonttools available, sometimes there are pyenv etc snafus so it seems like it should be here